### PR TITLE
Fix bearer token validation to properly verify Authorization header

### DIFF
--- a/app.js
+++ b/app.js
@@ -183,7 +183,25 @@ const verifyTestEndpointAuth = (req, res, next) => {
 
   // Check Authorization: Bearer header
   if (authHeader) {
-    const token = authHeader.replace('Bearer ', '');
+    // Verify the header has the correct Bearer scheme (case-insensitive)
+    const bearerMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (!bearerMatch) {
+      console.error('Malformed Authorization header: missing or invalid Bearer scheme');
+      return res.status(401).json({
+        status: 'error',
+        message: 'Unauthorized: Malformed Authorization header'
+      });
+    }
+
+    const token = bearerMatch[1].trim();
+    if (!token) {
+      console.error('Malformed Authorization header: missing token after Bearer scheme');
+      return res.status(401).json({
+        status: 'error',
+        message: 'Unauthorized: Missing token'
+      });
+    }
+
     if (timingSafeCompare(token, validApiKey)) {
       return next();
     }


### PR DESCRIPTION
Replace naive `replace('Bearer ', '')` with proper validation:
- Use regex `/^Bearer\s+(.+)$/i` to verify correct Bearer scheme
- Return 401 with specific error for malformed headers
- Trim extracted token before comparing with timingSafeCompare
- Handle case-insensitive Bearer prefix per RFC 7235