### PR TITLE
Refactor slash command to use /risk alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 **Author**: Anthony Fecarotta (freightCognition & linehaul.ai)
 **License**: MIT
 **Version**: 2.1.4
-**Repository**: https://github.com/freightcognition/mcp-slackbot
+**Repository**: https://github.com/freightcognition/risk-slackbot
 
 ## Architecture
 
@@ -24,7 +24,7 @@
 ### Core Components
 
 1. **Bolt App with Socket Mode** ([app.js](app.js))
-   - Slack command handler (`/mcp`) using `app.command()`
+   - Slack command handler (`/risk`) using `app.command()`
    - Multi-step wizard modal (4 steps) with view push/update
    - Action handlers for wizard navigation, pagination, and contact selection
    - Health check endpoint via `customRoutes` on port 3001
@@ -40,7 +40,7 @@
 
 3. **Slack Integration**
    - Socket Mode (WebSocket connection to Slack)
-   - Slash command (`/mcp`) via Bolt SDK
+   - Slash command (`/risk`) via Bolt SDK
    - Multi-step modal wizard with Block Kit UI
    - Channel broadcast of risk assessment summaries
    - Signature verification handled by Bolt
@@ -52,7 +52,7 @@
 
 ## Key Features
 
-- **Carrier Risk Assessment Wizard**: 4-step modal wizard initiated via `/mcp [DOT_NUMBER]`
+- **Carrier Risk Assessment Wizard**: 4-step modal wizard initiated via `/risk [DOT_NUMBER]`
   - Step 1: Carrier overview (name, MC#, DOT#, risk score, authority status)
   - Step 2: Incident reports with pagination
   - Step 3: VIN verifications with pagination (10 per page)
@@ -153,7 +153,7 @@ mcp-slackbot/
 
 ### Slack Handlers
 
-- **Command**: `/mcp` - Initiates wizard, fetches carrier data, opens Step 1 modal
+- **Command**: `/risk` - Initiates wizard, fetches carrier data, opens Step 1 modal
 - **Actions**: `wizard_next`, `wizard_back`, `wizard_vins_next`, `wizard_vins_prev`, `wizard_decline`, `select_contact`, `wizard_send_intellivite`
 - **View submissions**: `carrier_wizard`, `carrier_wizard_step4`
 - **View closed**: Cleanup handlers for wizard state and active assessments
@@ -226,10 +226,10 @@ bun run pm2:logs
 ## Slack Command Format
 
 ```
-/mcp [DOT_NUMBER]
+/risk [DOT_NUMBER]
 ```
 
-**Example**: `/mcp 12345`
+**Example**: `/risk 12345`
 
 Opens a 4-step wizard modal for the requesting user and broadcasts a risk assessment summary to the channel.
 
@@ -303,7 +303,7 @@ Opens a 4-step wizard modal for the requesting user and broadcasts a risk assess
 ## Contact & Support
 
 **Maintainer**: freightCognition
-**Issues**: https://github.com/freightcognition/mcp-slackbot/issues
+**Issues**: https://github.com/freightcognition/risk-slackbot/issues
 **Keywords**: slack, slackbot, mycarrierportal, fakebizprez, linehaul.ai
 
 ## Notes for AI Assistants

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ To use this bot, you need to create a Slack App:
 1. Navigate to **Features > Slash Commands**
 2. Click **Create New Command**
 3. Configure:
-   - **Command:** `/mcp`
+   - **Command:** `/risk`
    - **Request URL:** Use a placeholder URL (Socket Mode does not require a public endpoint)
    - **Short Description:** "Fetch MCP Carrier Risk Assessment"
    - **Usage Hint:** `[MC number]`
@@ -467,7 +467,7 @@ docker compose exec mcpslackbot node tests/test_refresh.js
 Test automatic token refresh when access token expires:
 
 1. Use an old/expired `BEARER_TOKEN`
-2. Trigger a Slack command: `/mcp MC123456`
+2. Trigger a Slack command: `/risk MC123456`
 3. Watch logs for automatic refresh:
    ```bash
    docker compose logs -f mcpslackbot

--- a/app.js
+++ b/app.js
@@ -1232,8 +1232,8 @@ async function _doRefreshAccessToken() {
   }
 }
 
-// /mcp command - Opens carrier assessment wizard modal
-slackApp.command("/mcp", async ({ command, ack, respond, client }) => {
+// /risk command - Opens carrier assessment wizard modal
+slackApp.command("/risk", async ({ command, ack, respond, client }) => {
   await ack();
 
   const { text, channel_id, trigger_id, user_id } = command;

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -408,7 +408,7 @@ describe("Wizard View Builders - null state handling", () => {
 });
 
 describe("MC number input normalization", () => {
-  // Mirrors the normalization logic in the /mcp command handler
+  // Mirrors the normalization logic in the /risk command handler
   const normalizeMcInput = (text) => text.trim().replace(/^mc/i, "");
   const isValidMcNumber = (mc) => /^\d{1,8}$/.test(mc);
 


### PR DESCRIPTION
Rename the `/mcp` slash command to `/risk` to better reflect its functionality of initiating a carrier risk assessment. This change ensures clarity and improves user experience.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/freightcognition/mcp-slackbot/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed the Slack slash command from `/mcp` to `/risk` across the app so the carrier assessment wizard is now triggered with `/risk`.
* **Documentation**
  * Updated all user-facing docs and examples to reference `/risk` and adjusted repository links accordingly.
* **Tests**
  * Aligned test comments to reference the `/risk` command (no test logic changed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR renames the Slack slash command from `/mcp` to `/risk` to better describe its carrier risk assessment purpose. The change is applied consistently across `app.js`, `README.md`, and the test comment, but `CLAUDE.md` — the developer/agent guide — still references `/mcp` in multiple places and should be updated to match.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; functional change is correct and isolated, with only a minor documentation gap in CLAUDE.md

Only P2 findings present — the rename is mechanically correct in all runtime and test files. The missed CLAUDE.md update is a docs-only oversight with no impact on behavior.

CLAUDE.md (not in the diff) still references `/mcp` and should be updated alongside this PR
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app.js | Renamed command handler from `/mcp` to `/risk` — single targeted change, no logic affected |
| README.md | Updated two documentation references from `/mcp` to `/risk` correctly |
| tests/app.test.js | Updated inline comment to reflect new `/risk` command name — no test logic changed |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Slack
    participant Bot as mcp-slackbot (app.js)

    User->>Slack: /risk MC123456
    Slack->>Bot: POST command event "/risk"
    Bot->>Slack: ack()
    Bot->>Slack: views.open (Step 1 modal)
    User->>Slack: Navigate wizard steps
    Slack->>Bot: view_submission / block_actions
    Bot->>Slack: views.push / views.update
    Bot->>Slack: Post risk summary to channel
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
app.js:1234-1235
**`CLAUDE.md` not updated with new command name**

`CLAUDE.md` still references `/mcp` in at least 5 places (lines 27, 43, 55, 156, 229, 232) describing the slash command and its usage examples. Since `CLAUDE.md` serves as the developer guide for AI agents and new contributors, leaving it out of sync will mislead anyone reading it after this rename.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor slash command to use /risk alia..."](https://github.com/freightcognition/mcp-slackbot/commit/b278b211d44ec1a9f405ef31647a14fb035b3cbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30354074)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->