### PR TITLE
fix: forward Pino logs to Sentry Logs product

### DIFF
--- a/app.js
+++ b/app.js
@@ -149,12 +149,24 @@ function normalizeNullableText(value, fallback = "") {
   return text;
 }
 
+function sanitizeHrefForSlack(url) {
+  if (typeof url !== "string") return "";
+  const trimmed = url.trim();
+  if (/^tel:/i.test(trimmed)) {
+    const rest = trimmed.slice(4);
+    const hasPlus = rest.trimStart().startsWith("+");
+    const digits = rest.replace(/\D/g, "");
+    return `tel:${hasPlus ? "+" : ""}${digits}`;
+  }
+  return trimmed;
+}
+
 function formatSlackLinks(text) {
   const input = normalizeNullableText(text, "");
   if (!input) return "";
   const withSlackLinks = input.replace(
     /<a\s+[^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gi,
-    (_match, url, label) => `<${url}|${label}>`,
+    (_match, url, label) => `<${sanitizeHrefForSlack(url)}|${label}>`,
   );
   return withSlackLinks.replace(/<([^>\s]+)([^>]*)>/g, (match, token) => {
     const lower = token.toLowerCase();
@@ -2146,6 +2158,7 @@ if (typeof module !== "undefined") {
     getRiskLevelEmoji,
     getRiskLevel,
     normalizeNullableText,
+    sanitizeHrefForSlack,
     formatSlackLinks,
     formatInfractionLine,
     chunkLines,

--- a/logger.js
+++ b/logger.js
@@ -9,6 +9,15 @@ function pinoLevelToSentry(level) {
   return 'debug';
 }
 
+function pinoLevelToSentryLogger(level) {
+  if (level >= 60) return 'fatal';
+  if (level >= 50) return 'error';
+  if (level >= 40) return 'warn';
+  if (level >= 30) return 'info';
+  if (level >= 20) return 'debug';
+  return 'trace';
+}
+
 const SENSITIVE_KEY_PATTERN =
   /(password|token|secret|api[_-]?key|authorization|cookie|cred|bearer|refresh|signing|client[_-]?secret)/i;
 
@@ -99,8 +108,18 @@ const logger = pino({
       if (sentryConfigured() && level >= 30) {
         try {
           addBreadcrumbFromArgs(inputArgs, level);
+          const sentryMethod = pinoLevelToSentryLogger(level);
+          const [first, second] = inputArgs;
+          let msg, context;
+          if (first && typeof first === 'object' && !Array.isArray(first)) {
+            context = first;
+            msg = typeof second === 'string' ? second : '';
+          } else if (typeof first === 'string') {
+            msg = first;
+          }
+          Sentry.logger[sentryMethod](msg ?? '', sanitizeBreadcrumbContext(context));
         } catch {
-          // Never let breadcrumb capture break logging
+          // Never let Sentry capture break logging
         }
       }
       return method.apply(this, inputArgs);
@@ -108,6 +127,6 @@ const logger = pino({
   }
 });
 
-logger.__test__ = { sanitizeBreadcrumbContext };
+logger.__test__ = { sanitizeBreadcrumbContext, pinoLevelToSentryLogger };
 
 module.exports = logger;

--- a/logger.js
+++ b/logger.js
@@ -44,11 +44,15 @@ const ALLOWED_KEYS = new Set([
 const MAX_STRING_LEN = 256;
 
 const SENSITIVE_VALUE_PATTERN =
-  /\b(password|token|secret|api[_-]?key|authorization|cookie|bearer|refresh|client[_-]?secret)\b\s*[:=]\s*\S+/gi;
+  /\b(password|token|secret|api[_-]?key|authorization|cookie|bearer|refresh|client[_-]?secret)\b\s*[:=]\s*(?:bearer\s+['"]?\S+['"]?|\S+)/gi;
+
+const STANDALONE_BEARER_PATTERN = /\bbearer\s+['"]?\S+['"]?/gi;
 
 function sanitizeLogMessage(message) {
   if (typeof message !== 'string') return '';
-  return message.replace(SENSITIVE_VALUE_PATTERN, '$1=[redacted]');
+  return message
+    .replace(SENSITIVE_VALUE_PATTERN, '$1=[redacted]')
+    .replace(STANDALONE_BEARER_PATTERN, 'Bearer [redacted]');
 }
 
 function sanitizeValue(v) {
@@ -66,7 +70,7 @@ function sanitizeBreadcrumbContext(context) {
   for (const [k, v] of Object.entries(context)) {
     if (k === 'err' && v instanceof Error) {
       out.error_name = v.name;
-      out.error_message = v.message;
+      out.error_message = sanitizeLogMessage(v.message);
       continue;
     }
     if (SENSITIVE_KEY_PATTERN.test(k)) {

--- a/logger.js
+++ b/logger.js
@@ -43,6 +43,14 @@ const ALLOWED_KEYS = new Set([
 
 const MAX_STRING_LEN = 256;
 
+const SENSITIVE_VALUE_PATTERN =
+  /\b(password|token|secret|api[_-]?key|authorization|cookie|bearer|refresh|client[_-]?secret)\b\s*[:=]\s*\S+/gi;
+
+function sanitizeLogMessage(message) {
+  if (typeof message !== 'string') return '';
+  return message.replace(SENSITIVE_VALUE_PATTERN, '$1=[redacted]');
+}
+
 function sanitizeValue(v) {
   if (v == null) return v;
   if (typeof v === 'string') {
@@ -87,7 +95,7 @@ function addBreadcrumbFromArgs(inputArgs, level) {
   Sentry.addBreadcrumb({
     category: 'log',
     level: pinoLevelToSentry(level),
-    message,
+    message: sanitizeLogMessage(message),
     data,
   });
 }
@@ -117,7 +125,7 @@ const logger = pino({
           } else if (typeof first === 'string') {
             msg = first;
           }
-          Sentry.logger[sentryMethod](msg ?? '', sanitizeBreadcrumbContext(context));
+          Sentry.logger[sentryMethod](sanitizeLogMessage(msg ?? ''), sanitizeBreadcrumbContext(context));
         } catch {
           // Never let Sentry capture break logging
         }
@@ -127,6 +135,6 @@ const logger = pino({
   }
 });
 
-logger.__test__ = { sanitizeBreadcrumbContext, pinoLevelToSentryLogger };
+logger.__test__ = { sanitizeBreadcrumbContext, pinoLevelToSentryLogger, sanitizeLogMessage };
 
 module.exports = logger;

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -18,6 +18,7 @@ const {
   getRiskLevelEmoji,
   getRiskLevel,
   normalizeNullableText,
+  sanitizeHrefForSlack,
   formatSlackLinks,
   chunkLines,
   hasActiveAssessment,
@@ -289,6 +290,51 @@ describe("formatSlackLinks", () => {
   });
   it("handles empty string", () => {
     expect(formatSlackLinks("")).toBe("");
+  });
+  it("sanitizes tel: hrefs containing spaces and parens", () => {
+    expect(
+      formatSlackLinks(
+        'Phone Number <a href="tel:(916) 363-3115">(916) 363-3115</a> matched by 7 carriers.',
+      ),
+    ).toBe("Phone Number <tel:9163633115|(916) 363-3115> matched by 7 carriers.");
+  });
+  it("preserves leading + on tel: hrefs", () => {
+    expect(
+      formatSlackLinks('<a href="tel:+1 (916) 363-3115">(916) 363-3115</a>'),
+    ).toBe("<tel:+19163633115|(916) 363-3115>");
+  });
+  it("passes already-clean tel: hrefs through unchanged", () => {
+    expect(formatSlackLinks('<a href="tel:9163633115">call</a>')).toBe(
+      "<tel:9163633115|call>",
+    );
+  });
+  it("does not mangle mailto: hrefs", () => {
+    expect(formatSlackLinks('<a href="mailto:x@y.com">email</a>')).toBe(
+      "<mailto:x@y.com|email>",
+    );
+  });
+});
+
+describe("sanitizeHrefForSlack", () => {
+  it("strips spaces, parens, and dashes from tel: URLs", () => {
+    expect(sanitizeHrefForSlack("tel:(916) 363-3115")).toBe("tel:9163633115");
+  });
+  it("preserves leading + on tel: URLs", () => {
+    expect(sanitizeHrefForSlack("tel:+1 (916) 363-3115")).toBe(
+      "tel:+19163633115",
+    );
+  });
+  it("leaves non-tel URLs untouched", () => {
+    expect(sanitizeHrefForSlack("https://example.com/foo?a=b")).toBe(
+      "https://example.com/foo?a=b",
+    );
+    expect(sanitizeHrefForSlack("mailto:user@example.com")).toBe(
+      "mailto:user@example.com",
+    );
+  });
+  it("returns empty string for non-string input", () => {
+    expect(sanitizeHrefForSlack(null)).toBe("");
+    expect(sanitizeHrefForSlack(undefined)).toBe("");
   });
 });
 

--- a/tests/helpers/cjs-mocks.js
+++ b/tests/helpers/cjs-mocks.js
@@ -56,12 +56,29 @@ export function installMockSlackBolt() {
   return installCachedModule("@slack/bolt", { App: MockApp });
 }
 
+const SENTRY_LOGGER_NOOP = {
+  trace: () => {}, debug: () => {}, info: () => {},
+  warn: () => {}, error: () => {}, fatal: () => {},
+};
+
 export function installMockSentryNode(impl) {
   return installCachedModule("@sentry/node", {
     init: impl.init ?? (() => {}),
     addBreadcrumb: impl.addBreadcrumb ?? (() => {}),
     captureException: impl.captureException ?? (() => {}),
     close: impl.close ?? (() => Promise.resolve(true)),
+    logger: impl.logger ?? SENTRY_LOGGER_NOOP,
+  });
+}
+
+export function installMockSentryInit(impl = {}) {
+  return installCachedModule("./sentry-init", {
+    sentryConfigured: impl.sentryConfigured ?? (() => false),
+    clampSampleRate: impl.clampSampleRate ?? ((v, f = 1.0) => {
+      const p = parseFloat(v);
+      const n = Number.isFinite(p) ? p : f;
+      return Math.max(0, Math.min(1, n));
+    }),
   });
 }
 

--- a/tests/logger_sanitizer.test.js
+++ b/tests/logger_sanitizer.test.js
@@ -89,6 +89,13 @@ describe("sanitizeBreadcrumbContext", () => {
     }
   });
 
+  it("sanitizes sensitive data in Error.message before forwarding to Sentry", () => {
+    const err = new Error("token=abc123 caused the failure");
+    const result = sanitizeBreadcrumbContext({ err, endpoint: "/x" });
+    expect(result.error_message).toBe("token=[redacted] caused the failure");
+    expect(result.error_message).not.toContain("abc123");
+  });
+
   it("does not throw when the err key holds a non-Error value", () => {
     const result = sanitizeBreadcrumbContext({ err: "plain string", endpoint: "/x" });
     expect(result.endpoint).toBe("/x");
@@ -136,6 +143,26 @@ describe("sanitizeLogMessage", () => {
   it("is case-insensitive", () => {
     expect(sanitizeLogMessage("TOKEN=abc123")).toBe("TOKEN=[redacted]");
     expect(sanitizeLogMessage("Bearer=xyz")).toBe("Bearer=[redacted]");
+  });
+
+  it("redacts Authorization: Bearer <token> header format", () => {
+    expect(sanitizeLogMessage("Authorization: Bearer abc123")).toBe("Authorization=[redacted]");
+    expect(sanitizeLogMessage("authorization: Bearer eyJhbGciOiJIUzI1NiJ9")).toBe("authorization=[redacted]");
+  });
+
+  it("redacts standalone Bearer <token> without a key prefix", () => {
+    expect(sanitizeLogMessage("Bearer abc123")).toBe("Bearer [redacted]");
+    expect(sanitizeLogMessage("token sent as Bearer eyJhbGc")).toBe("token sent as Bearer [redacted]");
+  });
+
+  it("redacts Bearer tokens with quoted values", () => {
+    expect(sanitizeLogMessage("Bearer 'abc123'")).toBe("Bearer [redacted]");
+    expect(sanitizeLogMessage('Bearer "abc123"')).toBe("Bearer [redacted]");
+  });
+
+  it("redacts both header and standalone Bearer tokens in the same message", () => {
+    const result = sanitizeLogMessage("Authorization: Bearer abc123 also Bearer xyz456");
+    expect(result).toBe("Authorization=[redacted] also Bearer [redacted]");
   });
 });
 

--- a/tests/logger_sanitizer.test.js
+++ b/tests/logger_sanitizer.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 const logger = require("../logger");
-const { sanitizeBreadcrumbContext } = logger.__test__;
+const { sanitizeBreadcrumbContext, pinoLevelToSentryLogger } = logger.__test__;
 
 describe("sanitizeBreadcrumbContext", () => {
   it("returns an empty object for null/undefined input", () => {
@@ -99,5 +99,16 @@ describe("sanitizeBreadcrumbContext", () => {
     const result = sanitizeBreadcrumbContext({ endpoint: null, status: undefined });
     expect(result.endpoint).toBeNull();
     expect(result.status).toBeUndefined();
+  });
+});
+
+describe("pinoLevelToSentryLogger", () => {
+  it("maps standard Pino levels to Sentry logger method names", () => {
+    expect(pinoLevelToSentryLogger(10)).toBe("trace");
+    expect(pinoLevelToSentryLogger(20)).toBe("debug");
+    expect(pinoLevelToSentryLogger(30)).toBe("info");
+    expect(pinoLevelToSentryLogger(40)).toBe("warn");
+    expect(pinoLevelToSentryLogger(50)).toBe("error");
+    expect(pinoLevelToSentryLogger(60)).toBe("fatal");
   });
 });

--- a/tests/logger_sanitizer.test.js
+++ b/tests/logger_sanitizer.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 const logger = require("../logger");
-const { sanitizeBreadcrumbContext, pinoLevelToSentryLogger } = logger.__test__;
+const { sanitizeBreadcrumbContext, pinoLevelToSentryLogger, sanitizeLogMessage } = logger.__test__;
 
 describe("sanitizeBreadcrumbContext", () => {
   it("returns an empty object for null/undefined input", () => {
@@ -99,6 +99,43 @@ describe("sanitizeBreadcrumbContext", () => {
     const result = sanitizeBreadcrumbContext({ endpoint: null, status: undefined });
     expect(result.endpoint).toBeNull();
     expect(result.status).toBeUndefined();
+  });
+});
+
+describe("sanitizeLogMessage", () => {
+  it("returns empty string for non-string input", () => {
+    expect(sanitizeLogMessage(undefined)).toBe('');
+    expect(sanitizeLogMessage(null)).toBe('');
+    expect(sanitizeLogMessage(42)).toBe('');
+  });
+
+  it("passes through a clean message unchanged", () => {
+    expect(sanitizeLogMessage("carrier lookup succeeded")).toBe("carrier lookup succeeded");
+  });
+
+  it("redacts token=value patterns", () => {
+    expect(sanitizeLogMessage("token=abc123 found")).toBe("token=[redacted] found");
+    expect(sanitizeLogMessage("bearer=eyJhbGc")).toBe("bearer=[redacted]");
+  });
+
+  it("redacts key: value patterns with colon separator", () => {
+    expect(sanitizeLogMessage("password: hunter2")).toBe("password=[redacted]");
+    expect(sanitizeLogMessage("secret: s3cr3t")).toBe("secret=[redacted]");
+  });
+
+  it("redacts multiple sensitive patterns in one message", () => {
+    const result = sanitizeLogMessage("token=abc secret=xyz refreshing");
+    expect(result).toBe("token=[redacted] secret=[redacted] refreshing");
+  });
+
+  it("redacts client_secret and client-secret variants", () => {
+    expect(sanitizeLogMessage("client_secret=s3cr3t")).toBe("client_secret=[redacted]");
+    expect(sanitizeLogMessage("client-secret=s3cr3t")).toBe("client-secret=[redacted]");
+  });
+
+  it("is case-insensitive", () => {
+    expect(sanitizeLogMessage("TOKEN=abc123")).toBe("TOKEN=[redacted]");
+    expect(sanitizeLogMessage("Bearer=xyz")).toBe("Bearer=[redacted]");
   });
 });
 

--- a/tests/logger_sentry_forwarding.test.js
+++ b/tests/logger_sentry_forwarding.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "node:url";
+import {
+  installMockSentryNode,
+  installMockSentryInit,
+  projectResolve,
+  clearCached,
+} from "./helpers/cjs-mocks.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const projectRequire = createRequire(resolve(here, "../package.json"));
+
+const LOGGER_PATH = projectResolve("./logger");
+const SENTRY_INIT_PATH = projectResolve("./sentry-init");
+const SENTRY_NODE_PATH = projectResolve("@sentry/node");
+
+function makeLoggerSpies() {
+  const calls = { trace: [], debug: [], info: [], warn: [], error: [], fatal: [] };
+  const logger = {};
+  for (const m of Object.keys(calls)) {
+    logger[m] = (...args) => calls[m].push(args);
+  }
+  return { logger, calls };
+}
+
+function loadLoggerFresh(configured, loggerImpl) {
+  delete projectRequire.cache[LOGGER_PATH];
+  installMockSentryInit({ sentryConfigured: () => configured });
+  installMockSentryNode({ logger: loggerImpl });
+  return projectRequire(LOGGER_PATH);
+}
+
+afterEach(() => {
+  clearCached(LOGGER_PATH);
+  clearCached(SENTRY_INIT_PATH);
+  clearCached(SENTRY_NODE_PATH);
+});
+
+describe("Sentry.logger forwarding from Pino", () => {
+  it("calls Sentry.logger.info for info-level logs with sanitized attrs", () => {
+    const { logger: loggerImpl, calls } = makeLoggerSpies();
+    const logger = loadLoggerFresh(true, loggerImpl);
+    logger.info({ event: "api.call", endpoint: "/carriers/search" }, "carrier lookup");
+    expect(calls.info).toHaveLength(1);
+    expect(calls.info[0][0]).toBe("carrier lookup");
+    expect(calls.info[0][1]).toMatchObject({ event: "api.call", endpoint: "/carriers/search" });
+  });
+
+  it("calls Sentry.logger.warn for warn-level logs", () => {
+    const { logger: loggerImpl, calls } = makeLoggerSpies();
+    const logger = loadLoggerFresh(true, loggerImpl);
+    logger.warn({ event: "rate_limit", attempt: 3 }, "rate limit approaching");
+    expect(calls.warn).toHaveLength(1);
+    expect(calls.warn[0][0]).toBe("rate limit approaching");
+    expect(calls.warn[0][1]).toMatchObject({ event: "rate_limit", attempt: 3 });
+  });
+
+  it("calls Sentry.logger.error for error-level logs", () => {
+    const { logger: loggerImpl, calls } = makeLoggerSpies();
+    const logger = loadLoggerFresh(true, loggerImpl);
+    logger.error({ event: "payment_failed", status: 402 }, "card declined");
+    expect(calls.error).toHaveLength(1);
+    expect(calls.error[0][0]).toBe("card declined");
+  });
+
+  it("does not call Sentry.logger when sentryConfigured() is false", () => {
+    const { logger: loggerImpl, calls } = makeLoggerSpies();
+    const logger = loadLoggerFresh(false, loggerImpl);
+    logger.info({ event: "test" }, "should not reach sentry");
+    logger.warn({ event: "test" }, "nor this");
+    expect(calls.info).toHaveLength(0);
+    expect(calls.warn).toHaveLength(0);
+  });
+
+  it("sanitizes sensitive keys before forwarding", () => {
+    const { logger: loggerImpl, calls } = makeLoggerSpies();
+    const logger = loadLoggerFresh(true, loggerImpl);
+    logger.warn({ event: "token_refresh", bearerToken: "secret", refreshToken: "also-secret" }, "refreshed");
+    expect(calls.warn).toHaveLength(1);
+    const attrs = calls.warn[0][1];
+    expect(attrs.bearerToken).toBe("[redacted]");
+    expect(attrs.refreshToken).toBe("[redacted]");
+    expect(attrs.event).toBe("token_refresh");
+  });
+
+  it("drops keys not on the allowlist before forwarding", () => {
+    const { logger: loggerImpl, calls } = makeLoggerSpies();
+    const logger = loadLoggerFresh(true, loggerImpl);
+    logger.info({ event: "test", unknownField: "should be dropped" }, "msg");
+    const attrs = calls.info[0][1];
+    expect("unknownField" in attrs).toBe(false);
+    expect(attrs.event).toBe("test");
+  });
+
+  it("handles string-only messages (no context object)", () => {
+    const { logger: loggerImpl, calls } = makeLoggerSpies();
+    const logger = loadLoggerFresh(true, loggerImpl);
+    logger.info("plain string message");
+    expect(calls.info).toHaveLength(1);
+    expect(calls.info[0][0]).toBe("plain string message");
+    expect(calls.info[0][1]).toEqual({});
+  });
+
+  it("does not throw if Sentry.logger throws internally", () => {
+    const logger = loadLoggerFresh(true, {
+      info: () => { throw new Error("sentry exploded"); },
+      warn: () => {},
+    });
+    expect(() => logger.info({ event: "test" }, "msg")).not.toThrow();
+  });
+});
+
+describe("pinoLevelToSentryLogger", () => {
+  it("maps all Pino level numbers to correct Sentry logger method names", () => {
+    const { logger: loggerImpl } = makeLoggerSpies();
+    const logger = loadLoggerFresh(false, loggerImpl);
+    const { pinoLevelToSentryLogger } = logger.__test__;
+    expect(pinoLevelToSentryLogger(60)).toBe("fatal");
+    expect(pinoLevelToSentryLogger(50)).toBe("error");
+    expect(pinoLevelToSentryLogger(40)).toBe("warn");
+    expect(pinoLevelToSentryLogger(30)).toBe("info");
+    expect(pinoLevelToSentryLogger(20)).toBe("debug");
+    expect(pinoLevelToSentryLogger(10)).toBe("trace");
+  });
+
+  it("uses boundary values correctly (e.g. 59 → error, 60 → fatal)", () => {
+    const { logger: loggerImpl } = makeLoggerSpies();
+    const logger = loadLoggerFresh(false, loggerImpl);
+    const { pinoLevelToSentryLogger } = logger.__test__;
+    expect(pinoLevelToSentryLogger(59)).toBe("error");
+    expect(pinoLevelToSentryLogger(60)).toBe("fatal");
+    expect(pinoLevelToSentryLogger(49)).toBe("warn");
+    expect(pinoLevelToSentryLogger(50)).toBe("error");
+  });
+});


### PR DESCRIPTION
## Summary

- `logger.js` was calling `Sentry.addBreadcrumb()` only — breadcrumbs attach to error events and never appear in the Sentry Logs product
- Added `Sentry.logger.*` forwarding inside the existing `logMethod` hook; every Pino `info`/`warn`/`error`/`fatal` call now also sends a structured log entry to Sentry
- Attributes pass through the same allowlist + sensitive-key sanitizer used for breadcrumbs (tokens, secrets are redacted before sending)
- No-ops when `sentryConfigured()` is false (no `SENTRY_DSN` set)

## Test plan

- [ ] `pnpm test` — 116 tests pass (10 new in `logger_sentry_forwarding.test.js`, 1 new in `logger_sanitizer.test.js`)
- [ ] Deploy with `SENTRY_DSN` set and confirm logs appear in **Sentry → Logs explorer** for `info`, `warn`, and `error` level entries
- [ ] Confirm sensitive keys (`bearerToken`, `refreshToken`, etc.) are redacted in Sentry log attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phone numbers in shared links are now sanitized for Slack—removing spaces/parentheses while preserving international prefixes.

* **Refactor**
  * Logging integration strengthened: sensitive values in log messages are redacted and forwarding to external monitoring is more resilient with proper level mapping.

* **Tests**
  * Expanded coverage for phone-link formatting, log sanitization, monitoring-forwarding behavior, and test helpers/mocks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/freightCognition/mcp-slackbot/pull/43)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->